### PR TITLE
🐛 Modify SSE connection handling for Puma

### DIFF
--- a/lib/dashing/app.rb
+++ b/lib/dashing/app.rb
@@ -1,4 +1,6 @@
+require 'securerandom'
 require 'sinatra'
+require 'sinatra/streaming'
 require 'sprockets'
 require 'sinatra/content_for'
 require 'rufus/scheduler'
@@ -33,7 +35,7 @@ set :root, Dir.pwd
 set :sprockets,     Sprockets::Environment.new(settings.root)
 set :assets_prefix, '/assets'
 set :digest_assets, false
-set server: 'puma', connections: [], history_file: 'history.yml'
+set server: 'puma', client_events: {}, history_file: 'history.yml'
 set :public_folder, File.join(settings.root, 'public')
 set :views, File.join(settings.root, 'dashboards')
 set :default_dashboard, nil
@@ -72,10 +74,15 @@ end
 get '/events', provides: 'text/event-stream' do
   protected!
   response.headers['X-Accel-Buffering'] = 'no' # Disable buffering for nginx
-  stream :keep_open do |out|
-    settings.connections << out
+  client_id = SecureRandom.uuid
+  stream do |out|
     out << latest_events
-    out.callback { settings.connections.delete(out) }
+    loop do
+      settings.client_events[client_id] = [] unless settings.client_events.has_key?(client_id)
+      while event = settings.client_events[client_id].shift do
+        out << event unless out.closed?
+      end
+    end
   end
 end
 
@@ -127,7 +134,14 @@ def send_event(id, body, target=nil)
   body[:updatedAt] ||= Time.now.to_i
   event = format_event(body.to_json, target)
   Sinatra::Application.settings.history[id] = event unless target == 'dashboards'
-  Sinatra::Application.settings.connections.each { |out| out << event }
+  max_event_queue_size = Sinatra::Application.settings.history.length * 2
+  Sinatra::Application.settings.client_events.each do |connection_id, events|
+    if events.length > max_event_queue_size
+      Sinatra::Application.settings.client_events.delete(connection_id)
+    else
+      events << event
+    end
+  end
 end
 
 def format_event(body, name=nil)

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -3,8 +3,7 @@ require 'haml'
 
 class AppTest < Dashing::Test
   def setup
-    @connection = []
-    app.settings.connections = [@connection]
+    app.settings.client_events = {'tests' => []}
     app.settings.auth_token = nil
     app.settings.default_dashboard = nil
     app.settings.history_file = File.join(Dir.tmpdir, 'history.yml')
@@ -49,8 +48,8 @@ class AppTest < Dashing::Test
     post '/widgets/some_widget', JSON.generate({value: 6})
     assert_equal 204, last_response.status
 
-    assert_equal 1, @connection.length
-    data = parse_data @connection[0]
+    assert_equal 1, app.settings.client_events.length
+    data = parse_data app.settings.client_events.values.first.first
     assert_equal 6, data['value']
     assert_equal 'some_widget', data['id']
     assert data['updatedAt']
@@ -72,19 +71,15 @@ class AppTest < Dashing::Test
     post '/widgets/some_widget', JSON.generate({value: 8})
     assert_equal 204, last_response.status
 
-    get '/events'
-    assert_equal 200, last_response.status
-    assert_equal 8, parse_data(@connection[0])['value']
+    assert_equal 8, parse_data(app.settings.client_events.values.first.first)['value']
   end
 
   def test_dashboard_events
     post '/dashboards/my_super_sweet_dashboard', JSON.generate({event: 'reload'})
     assert_equal 204, last_response.status
 
-    get '/events'
-    assert_equal 200, last_response.status
-    assert_equal 'dashboards', parse_event(@connection[0])
-    assert_equal 'reload', parse_data(@connection[0])['event']
+    assert_equal 'dashboards', parse_event(app.settings.client_events.values.first.first)
+    assert_equal 'reload', parse_data(app.settings.client_events.values.first.first)['event']
   end
 
   def test_get_dashboard


### PR DESCRIPTION
- Keep track of events on per-client basis
- Clients get a UUID
- If a client's event queue grows too big it gets dropped
- If a Puma thread tries to send the next batch of events to a client and it's event queue is dropped, the queue will be created
- Updated tests to match above changes
